### PR TITLE
added support for byte objects

### DIFF
--- a/azure-cosmosdb-table/azure/cosmosdb/table/_serialization.py
+++ b/azure-cosmosdb-table/azure/cosmosdb/table/_serialization.py
@@ -131,6 +131,7 @@ _PYTHON_TO_ENTITY_CONVERSIONS = {
     datetime: _to_entity_datetime,
     float: _to_entity_float,
     str: _to_entity_str,
+    byte: _to_entity_binary,
 }
 
 # Conversion from Edm type to a function which returns a tuple of the


### PR DESCRIPTION
Added missing support for Python byte objects to binary entity. This is usefull for storing numpy arrays in table storage.