### PR TITLE
Bug Fix: Require futures package only for python versions <= 2.7

### DIFF
--- a/azure-cosmosdb-table/setup.py
+++ b/azure-cosmosdb-table/setup.py
@@ -72,6 +72,7 @@ setup(
                          'cryptography',
                          'python-dateutil',
                          'requests',
-                     ] + (['futures'] if sys.version_info < (3, 0) else []),
+                         'futures; python_version<="2.7"'
+                     ],
     cmdclass=cmdclass
 )


### PR DESCRIPTION
Added check to include futures as a dependency only for python versions <= 2.7. The earlier didn't work for some reason.