### PR TITLE
Update storage dependency to follow semver

### DIFF
--- a/azure-cosmosdb-table/setup.py
+++ b/azure-cosmosdb-table/setup.py
@@ -68,7 +68,7 @@ setup(
     packages=find_packages(),
     install_requires=[
                          'azure-common>=1.1.5',
-                         'azure-storage-common>=1.1.0,<1.2.0',
+                         'azure-storage-common~=1.1',
                          'cryptography',
                          'python-dateutil',
                          'requests',


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cosmosdb-python/issues/28

This is moving from `[1.1.0, 1.2.0[` to `[1.1.0,2.0.0[`, according to semver recommendation on breaking changes.

Would fix instantly https://github.com/Azure/azure-sdk-for-python/issues/2818 as well.