### PR TITLE
Fixes #34, having OData type specified previously to property value no longer resets it

### DIFF
--- a/azure-cosmosdb-table/azure/cosmosdb/table/_serialization.py
+++ b/azure-cosmosdb-table/azure/cosmosdb/table/_serialization.py
@@ -198,8 +198,9 @@ def _convert_entity_to_json(source):
 
         # form the property node
         properties[name] = value
-        if mtype:
-            properties[name + '@odata.type'] = mtype
+        odataTypePropertyName = name + '@odata.type'
+        if mtype and odataTypePropertyName not in properties:
+            properties[odataTypePropertyName] = mtype
 
     # generate the entity_body
     return dumps(properties)


### PR DESCRIPTION
When specifying the EDM type of a property before a property whose value type is inferred it get's overwritten. If the EDM type of the property is specified afterwards the entity gets inserted with the expected property type. This PR fixes this by checking whether an EDM type was already set for a property when its type is inferred.

For more details please see #38 .