### PR TITLE
Fixed bug in escaping single quote character 

### DIFF
--- a/azure-cosmosdb-table/azure/cosmosdb/table/_serialization.py
+++ b/azure-cosmosdb-table/azure/cosmosdb/table/_serialization.py
@@ -57,8 +57,8 @@ _SUB_HEADERS = ['If-Match', 'Prefer', 'Accept', 'Content-Type', 'DataServiceVers
 def _get_entity_path(table_name, partition_key, row_key):
     return '/{0}(PartitionKey=\'{1}\',RowKey=\'{2}\')'.format(
         _to_str(table_name),
-        _to_str(partition_key),
-        _to_str(row_key))
+        _to_str(partition_key.replace('\'', '\'\'')),
+        _to_str(row_key.replace('\'', '\'\'')))
 
 
 def _update_storage_table_header(request):

--- a/azure-cosmosdb-table/tests/table/test_table_entity.py
+++ b/azure-cosmosdb-table/tests/table/test_table_entity.py
@@ -786,6 +786,39 @@ class StorageTableEntityTest(StorageTestCase):
             # Assert
 
     @record
+    def test_operations_on_entity_with_partition_key_having_single_quote(self):
+        partition_key_with_single_quote = "a''''b"
+        row_key_with_single_quote = "a''''b"
+
+        # Arrange
+        entity = self._insert_random_entity(pk=partition_key_with_single_quote, rk=row_key_with_single_quote)
+
+        # Act
+        sent_entity = self._create_updated_entity_dict(entity.PartitionKey, entity.RowKey)
+        resp = self.ts.insert_or_replace_entity(self.table_name, sent_entity)
+
+        # Assert
+        self.assertIsNotNone(resp)
+        received_entity = self.ts.get_entity(self.table_name, entity.PartitionKey, entity.RowKey)
+        self._assert_updated_entity(received_entity)
+
+        # Act
+        sent_entity['newField'] = 'newFieldValue'
+        resp = self.ts.update_entity(self.table_name, sent_entity)
+
+        # Assert
+        self.assertIsNotNone(resp)
+        received_entity = self.ts.get_entity(self.table_name, entity.PartitionKey, entity.RowKey)
+        self._assert_updated_entity(received_entity)
+        self.assertEqual(received_entity['newField'], 'newFieldValue')
+
+        # Act
+        resp = self.ts.delete_entity(self.table_name, received_entity.PartitionKey, received_entity.RowKey)
+
+        # Assert
+        self.assertIsNone(resp)
+
+    @record
     def test_unicode_property_value(self):
         ''' regression test for github issue #57'''
         # Arrange


### PR DESCRIPTION
 Escape single quotes according to OData Protocol Specification: "single quotes within string literals are represented as two consecutive single quotes".
The lack of this encoding was breaking replace, insertOrReplace and Delete entity functionalities when the partition key or row key had single quotes in them.